### PR TITLE
feat: add PNG document support for background removal

### DIFF
--- a/bot/filters.py
+++ b/bot/filters.py
@@ -64,6 +64,12 @@ class Document(BaseFilter):
         return message.document is not None
 
 
+class PngDocument(BaseFilter):
+    async def __call__(self, message: Message) -> bool:
+        return (message.document is not None and 
+                message.document.mime_type == 'image/png')
+
+
 class Photo(BaseFilter):
     async def __call__(self, message: Message) -> bool:
         return message.photo is not None

--- a/bot/image_editing/router.py
+++ b/bot/image_editing/router.py
@@ -1,7 +1,7 @@
 from aiogram import Router
 from aiogram.types import Message
 
-from bot.filters import TextCommand, Photo, StateCommand, CompositeFilters
+from bot.filters import TextCommand, Photo, StateCommand, CompositeFilters, PngDocument
 from bot.commands import get_remove_background_command
 from bot.utils import send_photo_as_file
 from config import TOKEN
@@ -11,7 +11,7 @@ imageEditingRouter = Router()
 
 @imageEditingRouter.message(TextCommand([get_remove_background_command()]))
 async def handle_remove_background_start(message: Message):
-    await message.answer("Пришлите фотографию, чтобы удалить фон.")
+    await message.answer("Пришлите фотографию или PNG файл (как документ), чтобы удалить фон.")
     stateService.set_current_state(message.from_user.id, StateTypes.ImageEditing)
 
 
@@ -30,6 +30,40 @@ async def handle_remove_background(message: Message, album):
     try:
 
         file_info = await message.bot.get_file(image.file_id)
+        file_url = f"https://api.telegram.org/file/bot{TOKEN}/{file_info.file_path}"
+
+        result = await imageEditing.remove_background(file_url)
+
+        image_url = result["data"]["task_result"]["task_output"]["image_url"]
+        await message.reply_photo(image_url)
+        await send_photo_as_file(
+            message,
+            image_url,
+            "Вот картинка в оригинальном качестве",
+            ext=".png"
+        )
+
+        await tokenizeService.update_token(message.from_user.id, 400, "subtract")
+        await message.answer(f"""
+🤖 Затрачено на удаление фона изображения 400⚡️
+
+❔ /help - Информация по ⚡️
+""")
+
+    except Exception as e:
+        print(e)
+    finally:
+        await wait_message.delete()
+
+
+@imageEditingRouter.message(CompositeFilters([PngDocument(), StateCommand(StateTypes.ImageEditing)]))
+async def handle_remove_background_png(message: Message):
+    stateService.set_current_state(message.from_user.id, StateTypes.Default)
+    wait_message = await message.answer("**⌛️Ожидайте ответ...**")
+
+    try:
+        document = message.document
+        file_info = await message.bot.get_file(document.file_id)
         file_url = f"https://api.telegram.org/file/bot{TOKEN}/{file_info.file_path}"
 
         result = await imageEditing.remove_background(file_url)


### PR DESCRIPTION
## 🚀 Summary

This PR adds support for PNG files sent as documents to the background removal feature, addressing issue #40.

## 📋 Changes Made

- **New Filter**: Added `PngDocument` filter to detect PNG files sent as documents (MIME type: `image/png`)
- **Enhanced Router**: Added dedicated handler for PNG documents in the image editing router
- **Updated Instructions**: Modified user-facing message to inform users that PNG files are supported
- **Consistent Behavior**: PNG documents use the same processing flow and token cost (400⚡️) as regular photos

## 🔧 Technical Details

### Files Modified:
- `bot/filters.py` - Added `PngDocument` filter class
- `bot/image_editing/router.py` - Added PNG document handler and updated user instructions

### How it Works:
1. When users send the background removal command, they're now informed they can send either photos or PNG documents
2. The system detects PNG documents using the MIME type filter
3. PNG documents are processed using the same background removal API as photos
4. Results are returned in PNG format to preserve transparency

## 🧪 Testing

- ✅ Syntax validation passed for all modified files
- ✅ Import structure verified
- ✅ Filter logic tested
- ✅ Handler integration confirmed

## 🎯 Resolves

Fixes #40

---

🤖 Generated with [Claude Code](https://claude.ai/code)